### PR TITLE
fix: not output normal close error

### DIFF
--- a/websocket.go
+++ b/websocket.go
@@ -668,7 +668,14 @@ func (c *wsConn) handleWsConn(ctx context.Context) {
 				return // remote closed
 			}
 
-			log.Warnw("websocket error", "error", err)
+			// https://github.com/gorilla/websocket/blob/main/conn_test.go#L355
+			// 从测试用例来看，这个错误是预期之内的
+			if e, ok := err.(*websocket.CloseError); ok && e.Code == websocket.CloseNormalClosure {
+				log.Debugw("websocket error", "error", err)
+			} else {
+				log.Warnw("websocket error", "error", err)
+			}
+
 			// only client needs to reconnect
 			if !c.tryReconnect(ctx) {
 				return // failed to reconnect


### PR DESCRIPTION
fix: https://github.com/ipfs-force-community/go-jsonrpc/pull/23/files

在 pr 23 中把日志级别做了调整，导致打印出来较多干扰日志


![image](https://github.com/ipfs-force-community/go-jsonrpc/assets/69969590/a347e6f6-2ecd-486e-a414-a04f6049a8e1)
